### PR TITLE
Feat: Added Sentry integration for exception metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,9 @@ The development environment assumes you have the following prerequisites:
 - If iteration on UI changes run the project with `yarn watch` which will monitor the JavaScript project and rebuild when you make code changes and then `ensure new-phone-who-dis` after making your change
 - Avoid commiting `index.html` as the development version overrides the production version
 
-
 #### Important Note
 
-By installing NPWD you agree to the use of the following diagnostic package, Sentry, (in use within the React portion of NPWD), that automatically 
+By installing NPWD you agree to the use of the following diagnostic package, Sentry, (in use within the React portion of NPWD), that automatically
 uploads relevant sesssion details and stack traces whenever an exception is thrown. We use these metrics to further
-improve the quality of the phone. To explicitly disable this (we urge you not to as its incredibly useful metrics for us). 
+improve the quality of the phone. To explicitly disable this (we urge you not to as its incredibly useful metrics for us).
 Please change the `SentryErrorMetrics` setting to `false` in `phone/config/default.json` and rebuild the phone.

--- a/README.md
+++ b/README.md
@@ -77,3 +77,11 @@ The development environment assumes you have the following prerequisites:
 - If iterating on client/server Lua make your change and then `ensure new-phone-who-dis` in the fivem server terminal
 - If iteration on UI changes run the project with `yarn watch` which will monitor the JavaScript project and rebuild when you make code changes and then `ensure new-phone-who-dis` after making your change
 - Avoid commiting `index.html` as the development version overrides the production version
+
+
+#### Important Note
+
+By installing NPWD you agree to the use of the following diagnostic package, Sentry, (in use within the React portion of NPWD), that automatically 
+uploads relevant sesssion details and stack traces whenever an exception is thrown. We use these metrics to further
+improve the quality of the phone. To explicitly disable this (we urge you not to as its incredibly useful metrics for us). 
+Please change the `SentryErrorMetrics` setting to `false` in `phone/config/default.json` and rebuild the phone.

--- a/phone/package.json
+++ b/phone/package.json
@@ -13,6 +13,8 @@
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.56",
     "@popperjs/core": "^2.5.3",
+    "@sentry/react": "^5.29.2",
+    "@sentry/tracing": "^5.29.2",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",

--- a/phone/src/config/default.json
+++ b/phone/src/config/default.json
@@ -44,5 +44,6 @@
       },
       "divider": "rgba(255, 255, 255, 0.12)"
     }
-  }
+  },
+  "SentryErrorMetrics": true
 }

--- a/phone/src/index.tsx
+++ b/phone/src/index.tsx
@@ -3,11 +3,27 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { HashRouter } from "react-router-dom";
 import { RecoilRoot } from "recoil";
-
+import * as Sentry from "@sentry/react";
+import { Integrations } from "@sentry/tracing";
 import "./main.css";
 import Phone from "./Phone";
 import TwitterNotification from "./apps/twitter/components/notification/TwitterNotification";
 import { BankNotification } from "./apps/bank/components/notification/BankNotification";
+import PhoneConfig from './config/default.json'
+
+// Enable Sentry when config setting is true
+if (PhoneConfig.SentryErrorMetrics) {
+  Sentry.init({
+    dsn: "https://71fff4e8f11543fa8dbe7acd0f94fb5d@o478949.ingest.sentry.io/5581619",
+    autoSessionTracking: true,
+    integrations: [
+      new Integrations.BrowserTracing(),
+    ],
+    // We recommend adjusting this value in production, or using tracesSampler
+    // for finer control
+    tracesSampleRate: 1.0,
+  })
+}
 
 ReactDOM.render(
   <HashRouter>

--- a/phone/src/index.tsx
+++ b/phone/src/index.tsx
@@ -1,28 +1,27 @@
-import "@babel/polyfill";
-import React from "react";
-import ReactDOM from "react-dom";
-import { HashRouter } from "react-router-dom";
-import { RecoilRoot } from "recoil";
-import * as Sentry from "@sentry/react";
-import { Integrations } from "@sentry/tracing";
-import "./main.css";
-import Phone from "./Phone";
-import TwitterNotification from "./apps/twitter/components/notification/TwitterNotification";
-import { BankNotification } from "./apps/bank/components/notification/BankNotification";
-import PhoneConfig from './config/default.json'
+import '@babel/polyfill';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { HashRouter } from 'react-router-dom';
+import { RecoilRoot } from 'recoil';
+import * as Sentry from '@sentry/react';
+import { Integrations } from '@sentry/tracing';
+import './main.css';
+import Phone from './Phone';
+import TwitterNotification from './apps/twitter/components/notification/TwitterNotification';
+import { BankNotification } from './apps/bank/components/notification/BankNotification';
+import PhoneConfig from './config/default.json';
 
 // Enable Sentry when config setting is true
 if (PhoneConfig.SentryErrorMetrics) {
   Sentry.init({
-    dsn: "https://71fff4e8f11543fa8dbe7acd0f94fb5d@o478949.ingest.sentry.io/5581619",
+    dsn:
+      'https://71fff4e8f11543fa8dbe7acd0f94fb5d@o478949.ingest.sentry.io/5581619',
     autoSessionTracking: true,
-    integrations: [
-      new Integrations.BrowserTracing(),
-    ],
+    integrations: [new Integrations.BrowserTracing()],
     // We recommend adjusting this value in production, or using tracesSampler
     // for finer control
     tracesSampleRate: 1.0,
-  })
+  });
 }
 
 ReactDOM.render(
@@ -33,5 +32,5 @@ ReactDOM.render(
       <Phone />
     </RecoilRoot>
   </HashRouter>,
-  document.getElementById("root")
+  document.getElementById('root')
 );

--- a/phone/yarn.lock
+++ b/phone/yarn.lock
@@ -1556,6 +1556,81 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.5.3.tgz#4982b0b66b7a4cf949b86f5d25a8cf757d3cfd9d"
   integrity sha512-RFwCobxsvZ6j7twS7dHIZQZituMIDJJNHS/qY6iuthVebxS3zhRY+jaC2roEKiAYaVuTcGmX6Luc6YBcf6zJVg==
 
+"@sentry/browser@5.29.2":
+  version "5.29.2"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.29.2.tgz#51adb4005511b1a4a70e4571880fc6653d651f91"
+  integrity sha512-uxZ7y7rp85tJll+RZtXRhXPbnFnOaxZqJEv05vJlXBtBNLQtlczV5iCtU9mZRLVHDtmZ5VVKUV8IKXntEqqDpQ==
+  dependencies:
+    "@sentry/core" "5.29.2"
+    "@sentry/types" "5.29.2"
+    "@sentry/utils" "5.29.2"
+    tslib "^1.9.3"
+
+"@sentry/core@5.29.2":
+  version "5.29.2"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.29.2.tgz#9e05fe197234161d57aabaf52fab336a7c520d81"
+  integrity sha512-7WYkoxB5IdlNEbwOwqSU64erUKH4laavPsM0/yQ+jojM76ErxlgEF0u//p5WaLPRzh3iDSt6BH+9TL45oNZeZw==
+  dependencies:
+    "@sentry/hub" "5.29.2"
+    "@sentry/minimal" "5.29.2"
+    "@sentry/types" "5.29.2"
+    "@sentry/utils" "5.29.2"
+    tslib "^1.9.3"
+
+"@sentry/hub@5.29.2":
+  version "5.29.2"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.29.2.tgz#208f10fe6674695575ad74182a1151f71d6df00a"
+  integrity sha512-LaAIo2hwUk9ykeh9RF0cwLy6IRw+DjEee8l1HfEaDFUM6TPGlNNGObMJNXb9/95jzWp7jWwOpQjoIE3jepdQJQ==
+  dependencies:
+    "@sentry/types" "5.29.2"
+    "@sentry/utils" "5.29.2"
+    tslib "^1.9.3"
+
+"@sentry/minimal@5.29.2":
+  version "5.29.2"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.29.2.tgz#420bebac8d03d30980fdb05c72d7b253d8aa541b"
+  integrity sha512-0aINSm8fGA1KyM7PavOBe1GDZDxrvnKt+oFnU0L+bTcw8Lr+of+v6Kwd97rkLRNOLw621xP076dL/7LSIzMuhw==
+  dependencies:
+    "@sentry/hub" "5.29.2"
+    "@sentry/types" "5.29.2"
+    tslib "^1.9.3"
+
+"@sentry/react@^5.29.2":
+  version "5.29.2"
+  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-5.29.2.tgz#e0e2055db6f9c7a3957630e726b23d6a0f2d12f2"
+  integrity sha512-Fvh4l6/wrnO3FWqte7lPUsuWE5o6t3FHwZqVINgCIabpwPMorvOVzm/gwG7uzhuCoyNTP28svR670sl4BnRuTg==
+  dependencies:
+    "@sentry/browser" "5.29.2"
+    "@sentry/minimal" "5.29.2"
+    "@sentry/types" "5.29.2"
+    "@sentry/utils" "5.29.2"
+    hoist-non-react-statics "^3.3.2"
+    tslib "^1.9.3"
+
+"@sentry/tracing@^5.29.2":
+  version "5.29.2"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-5.29.2.tgz#6012788547d2ab7893799d82c4941bda145dcd47"
+  integrity sha512-iumYbVRpvoU3BUuIooxibydeaOOjl5ysc+mzsqhRs2NGW/C3uKAsFXdvyNfqt3bxtRQwJEhwJByLP2u3pLThpw==
+  dependencies:
+    "@sentry/hub" "5.29.2"
+    "@sentry/minimal" "5.29.2"
+    "@sentry/types" "5.29.2"
+    "@sentry/utils" "5.29.2"
+    tslib "^1.9.3"
+
+"@sentry/types@5.29.2":
+  version "5.29.2"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.29.2.tgz#ac87383df1222c2d9b9f8f9ed7a6b86ea41a098a"
+  integrity sha512-dM9wgt8wy4WRty75QkqQgrw9FV9F+BOMfmc0iaX13Qos7i6Qs2Q0dxtJ83SoR4YGtW8URaHzlDtWlGs5egBiMA==
+
+"@sentry/utils@5.29.2":
+  version "5.29.2"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.29.2.tgz#99a5cdda2ea19d34a41932f138d470adcb3ee673"
+  integrity sha512-nEwQIDjtFkeE4k6yIk4Ka5XjGRklNLThWLs2xfXlL7uwrYOH2B9UBBOOIRUraBm/g/Xrra3xsam/kRxuiwtXZQ==
+  dependencies:
+    "@sentry/types" "5.29.2"
+    tslib "^1.9.3"
+
 "@sheerun/mutationobserver-shim@^0.3.2":
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz#5405ee8e444ed212db44e79351f0c70a582aae25"
@@ -11490,7 +11565,7 @@ ts-pnp@^1.1.6:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
 
-tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==


### PR DESCRIPTION
As the title says. There is an option added to `config/default.json` to disable it for users worried about privacy concerns.