### PR TITLE
feat(client/net): Promisfied net events

### DIFF
--- a/resources/client/cl_utils.ts
+++ b/resources/client/cl_utils.ts
@@ -1,0 +1,59 @@
+import { uuidv4 } from '../utils/fivem';
+
+interface ISettings {
+  promiseTimeout: number;
+}
+
+interface ISettingsParams {
+  promiseTimeout?: number;
+}
+
+export default class ClientUtils {
+  private _settings: ISettings;
+  private _defaultSettings: ISettings = {
+    promiseTimeout: 5000,
+  };
+
+  constructor(settings?: ISettingsParams) {
+    this.setSettings(settings);
+  }
+
+  public setSettings(settings: ISettingsParams) {
+    this._settings = {
+      ...this._defaultSettings,
+      ...settings,
+    };
+  }
+
+  public emitNetPromise<T = any>(
+    eventName: string,
+    ...args: any[]
+  ): Promise<T> {
+    return new Promise((resolve, reject) => {
+      let hasTimedOut = false;
+
+      setTimeout(() => {
+        hasTimedOut = true;
+        reject(
+          `${eventName} has timed out after ${this._settings.promiseTimeout} ms`
+        );
+      }, this._settings.promiseTimeout);
+
+      // Have to use this as the regular uuid refused to work here for some
+      // fun reason
+      const uniqId = uuidv4();
+
+      const listenEventName = `${eventName}:${uniqId}`;
+
+      emitNet(eventName, listenEventName, ...args);
+
+      const handleListenEvent = (data: T, err: unknown) => {
+        removeEventListener(listenEventName, handleListenEvent);
+        if (hasTimedOut) return;
+        if (err) reject(err);
+        resolve(data);
+      };
+      onNet(listenEventName, handleListenEvent);
+    });
+  }
+}

--- a/resources/client/client.ts
+++ b/resources/client/client.ts
@@ -1,4 +1,5 @@
 import { Client } from 'esx.js';
+import ClientUtils from './cl_utils';
 
 import './cl_main';
 import './cl_twitter';
@@ -17,3 +18,5 @@ setTick(() => {
     emit('esx:getSharedObject', (obj: Client) => (ESX = obj));
   }
 });
+
+export const ClUtils = new ClientUtils();

--- a/resources/utils/fivem.ts
+++ b/resources/utils/fivem.ts
@@ -1,2 +1,28 @@
 // https://forum.cfx.re/t/typescript-vs-lua-questions/612483/11
 export const Delay = (ms: number) => new Promise((res) => setTimeout(res, ms));
+
+// Credits to d0p3t
+// https://github.com/d0p3t/fivem-js/blob/master/src/utils/UUIDV4.ts
+export const uuidv4 = (): string => {
+  let uuid = '';
+  for (let ii = 0; ii < 32; ii += 1) {
+    switch (ii) {
+      case 8:
+      case 20:
+        uuid += '-';
+        uuid += ((Math.random() * 16) | 0).toString(16);
+        break;
+      case 12:
+        uuid += '-';
+        uuid += '4';
+        break;
+      case 16:
+        uuid += '-';
+        uuid += ((Math.random() * 4) | 8).toString(16);
+        break;
+      default:
+        uuid += ((Math.random() * 16) | 0).toString(16);
+    }
+  }
+  return uuid;
+};


### PR DESCRIPTION
This new Feature allows for us to wrap net events in a promise. Here are some examples.

## Client
```ts
try {
  const result = await ClUtils.emitNetPromise(
    'npwd:promiseEvent',
    'arg1',
    'arg2'
  );
  console.log('Resolved:', result);
// If the promise is rejected, we catch it here
} catch (e) {
  console.error('Promise Rejected:', e);
}
```
## Server
This is how we listen to these promised events on the server. The first param to the callback will always be the name of the event that we must emit back to the client. The rest of the params, are whatever was passed to `emitNetPromise`. When responding, we must use the passed eventName, the source, and either the result or an error. The following example is a successful server transaction, where the data returned is 'Amazing data returned'.
```ts
onNet('npwd:promiseEvent', (eventName: string, arg1: string, arg2: string) => {
  const _source = (global as any).source;

  emitNet(eventName, source, 'Amazing data returned');
});
````

If we wanted to inform the client an error has occurred, and wish to reject the promise, we do this:
```ts
onNet('npwd:promiseEvent', (eventName: string, test1: string, test2: string) => {
  const _source = (global as any).source;

  emitNet(eventName, source, null, 'Error has occurred, you suck');
});
```
The first argument passed to the return event will always be data that was successfully retrieved according to the event's scope. The second argument is an error to be sent to the client, this will be passed to the Promise rejection.