### PR TITLE
Fix: Call history is now sorted.

### DIFF
--- a/resources/server/sv_call.ts
+++ b/resources/server/sv_call.ts
@@ -56,7 +56,7 @@ async function updateCall(call: ICall, isAccepted: boolean, end: number) {
 
 async function fetchCalls(phoneNumber: string): Promise<ICall[]> {
   const query =
-    'SELECT * FROM npwd_calls WHERE receiver = ? OR transmitter = ?';
+    'SELECT * FROM npwd_calls WHERE receiver = ? OR transmitter = ? ORDER BY id DESC';
   const [result] = await pool.query(query, [phoneNumber, phoneNumber]);
   const calls = <ICall[]>result;
   return calls;


### PR DESCRIPTION
Call history Is now ordered by ID so recent calls show up first instead of last. Previously it was just at the bottom.

(Courtesy of Chip)