### PR TITLE
[Bug] Yarn watch isn't working

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -15,6 +15,6 @@ ui_page 'resources/html/index.html'
 
 files {
     'resources/html/index.html',
-    'resources/html/main.js',
+    'resources/html/*.js',
     'resources/html/media/**/*'
 }


### PR DESCRIPTION
"watch" in the phone package.json allows rebuilds on any code changes. This doesn't seem functional as of [this commit](https://discord.com/channels/791854454760013827/791854455468458042/816454853621710868) which excludes `dev.js` from the `fxmanifest.lua`.

This change just wildcards JS files so both `yarn build` and `yarn watch` are functional.