### PR TITLE
tweak(phone/snackbar-provider): Altered API

### DIFF
--- a/phone/src/apps/bank/hooks/useBankService.ts
+++ b/phone/src/apps/bank/hooks/useBankService.ts
@@ -4,17 +4,26 @@ import { useTransactions } from './useTransactions';
 import { useCredentials } from './useCredentials';
 import { useSetRecoilState } from 'recoil';
 import { useBankNotification } from './useBankNotification';
-import { useSnackbar } from '../../../ui/hooks/useSnackbar';
+import { IAlert, useSnackbar } from '../../../ui/hooks/useSnackbar';
+import { useTranslation } from 'react-i18next';
 
 export const useBankService = () => {
   const setTransaction = useSetRecoilState(bankState.transactions);
   const setCredentials = useSetRecoilState(bankState.bankCredentials);
   const setNotification = useSetRecoilState(bankState.notification);
   const { addAlert } = useSnackbar();
+  const { t } = useTranslation();
+
+  const handleAddAlert = ({ message, type }: IAlert) => {
+    addAlert({
+      message: t(`APPS_${message}`),
+      type,
+    });
+  };
 
   useNuiEvent('BANK', 'setTransaction', setTransaction);
   useNuiEvent('BANK', 'setCredentials', setCredentials);
-  useNuiEvent('BANK', 'setAlert', addAlert);
+  useNuiEvent('BANK', 'setAlert', handleAddAlert);
   useNuiEvent('BANK', 'setNotification', setNotification);
   return { useTransactions, useCredentials, useBankNotification };
 };

--- a/phone/src/apps/calculator/components/Calculator.tsx
+++ b/phone/src/apps/calculator/components/Calculator.tsx
@@ -4,6 +4,7 @@ import { Grid, makeStyles, Box, Paper, Fab } from '@material-ui/core';
 import { setClipboard } from '../../../os/phone/hooks/useClipboard';
 import FileCopyIcon from '@material-ui/icons/FileCopy';
 import { useSnackbar } from '../../../ui/hooks/useSnackbar';
+import { useTranslation } from 'react-i18next';
 
 const useStyles = makeStyles((theme) => ({
   button: {
@@ -59,6 +60,8 @@ export const Calculator = ({ ...props }) => {
     [result],
   );
 
+  const { t } = useTranslation();
+
   return (
     <Box display="flex" flexDirection="column">
       <Box flexGrow={1} component={Paper} p={4} className={classes.result}>
@@ -66,7 +69,12 @@ export const Calculator = ({ ...props }) => {
           size="small"
           onClick={() => {
             setClipboard(resultStr);
-            addAlert({ message: 'CALCULATOR_COPIED', type: 'info' });
+            addAlert({
+              message: t('GENERIC_WRITE_TO_CLIPBOARD_MESSAGE', {
+                content: 'number',
+              }),
+              type: 'success',
+            });
           }}
           className={classes.copyFab}
         >

--- a/phone/src/apps/contacts/hooks/useContactsService.ts
+++ b/phone/src/apps/contacts/hooks/useContactsService.ts
@@ -2,13 +2,22 @@ import { useNuiEvent } from '../../../os/nui-events/hooks/useNuiEvent';
 import { useSetRecoilState } from 'recoil';
 import { contactsState } from './state';
 import { useContacts } from './useContacts';
-import { useSnackbar } from '../../../ui/hooks/useSnackbar';
+import { IAlert, useSnackbar } from '../../../ui/hooks/useSnackbar';
+import { useTranslation } from 'react-i18next';
 
 export const useContactsService = () => {
   const setContacts = useSetRecoilState(contactsState.contacts);
   const { addAlert } = useSnackbar();
+  const { t } = useTranslation();
+
+  const handleAddAlert = ({ message, type }: IAlert) => {
+    addAlert({
+      message: t(`APPS_${message}`),
+      type,
+    });
+  };
 
   useNuiEvent('CONTACTS', 'setContacts', setContacts);
-  useNuiEvent('CONTACTS', 'setAlert', addAlert);
+  useNuiEvent('CONTACTS', 'setAlert', handleAddAlert);
   return useContacts();
 };

--- a/phone/src/apps/messages/hooks/useMessageService.ts
+++ b/phone/src/apps/messages/hooks/useMessageService.ts
@@ -1,8 +1,10 @@
 import { useSetRecoilState } from 'recoil';
 import { messageState } from './state';
 import { useNuiEvent } from '../../../os/nui-events/hooks/useNuiEvent';
-import { useSnackbar } from '../../../ui/hooks/useSnackbar';
+import { IAlert, useSnackbar } from '../../../ui/hooks/useSnackbar';
+import { useTranslation } from 'react-i18next';
 import { useMessageNotifications } from './useMessageNotifications';
+import { useCallback } from 'react';
 
 export const useMessagesService = () => {
   const setMessageGroups = useSetRecoilState(messageState.messageGroups);
@@ -10,11 +12,22 @@ export const useMessagesService = () => {
   const setCreateMessageGroupResult = useSetRecoilState(messageState.createMessageGroupResult);
   const { addAlert } = useSnackbar();
   const { setNotification } = useMessageNotifications();
+  const { t } = useTranslation();
+
+  const handleAddAlert = useCallback(
+    ({ message, type }: IAlert) => {
+      addAlert({
+        message: t(`APPS_${message}`),
+        type,
+      });
+    },
+    [addAlert, t],
+  );
 
   useNuiEvent('MESSAGES', 'phone:fetchMessageGroupsSuccess', setMessageGroups);
   useNuiEvent('MESSAGES', 'phone:fetchMessagesSuccess', setMessages);
   useNuiEvent('MESSAGES', 'phone:createMessageGroupSuccess', setCreateMessageGroupResult);
   useNuiEvent('MESSAGES', 'phone:createMessageGroupFailed', setCreateMessageGroupResult);
-  useNuiEvent('MESSAGES', 'phone:setMessagesAlert', addAlert);
   useNuiEvent('MESSAGES', 'createMessagesBroadcast', setNotification);
+  useNuiEvent('MESSAGES', 'phone:setMessagesAlert', handleAddAlert);
 };

--- a/phone/src/apps/notes/hooks/useNotesService.ts
+++ b/phone/src/apps/notes/hooks/useNotesService.ts
@@ -1,12 +1,21 @@
 import { useSetRecoilState } from 'recoil';
 import { useNuiEvent } from '../../../os/nui-events/hooks/useNuiEvent';
 import { noteStates } from './state';
-import { useSnackbar } from '../../../ui/hooks/useSnackbar';
+import { IAlert, useSnackbar } from '../../../ui/hooks/useSnackbar';
+import { useTranslation } from 'react-i18next';
 
 export const useNotesService = () => {
   const { addAlert } = useSnackbar();
   const setNotes = useSetRecoilState(noteStates.noteItems);
+  const { t } = useTranslation();
+
+  const handleAddAlert = ({ message, type }: IAlert) => {
+    addAlert({
+      message: t(`APPS_${message}`),
+      type,
+    });
+  };
 
   useNuiEvent('NOTES', 'setNotes', setNotes);
-  useNuiEvent('NOTES', 'setAlert', addAlert);
+  useNuiEvent('NOTES', 'setAlert', handleAddAlert);
 };

--- a/phone/src/apps/sellout/hooks/useSelloutService.ts
+++ b/phone/src/apps/sellout/hooks/useSelloutService.ts
@@ -2,13 +2,22 @@ import { useNuiEvent } from '../../../os/nui-events/hooks/useNuiEvent';
 import { selloutState } from './state';
 import { useListing } from './useListing';
 import { useSetRecoilState } from 'recoil';
-import { useSnackbar } from '../../../ui/hooks/useSnackbar';
+import { IAlert, useSnackbar } from '../../../ui/hooks/useSnackbar';
+import { useTranslation } from 'react-i18next';
 
 export const useSelloutService = () => {
   const setSellout = useSetRecoilState(selloutState.listing);
   const { addAlert } = useSnackbar();
+  const { t } = useTranslation();
 
-  useNuiEvent('SELLOUT', 'setAlert', addAlert);
+  const handleAddAlert = ({ message, type }: IAlert) => {
+    addAlert({
+      message: t(`APPS_${message}`),
+      type,
+    });
+  };
+
+  useNuiEvent('SELLOUT', 'setAlert', handleAddAlert);
   useNuiEvent('SELLOUT', 'setListings', setSellout);
   return useListing();
 };

--- a/phone/src/apps/twitter/hooks/useTwitterService.ts
+++ b/phone/src/apps/twitter/hooks/useTwitterService.ts
@@ -5,8 +5,9 @@ import { useNuiEvent } from '../../../os/nui-events/hooks/useNuiEvent';
 import { IMAGE_DELIMITER } from '../utils/images';
 import { APP_TWITTER } from '../utils/constants';
 import { twitterState } from './state';
-import { useSnackbar } from '../../../ui/hooks/useSnackbar';
+import { IAlert, useSnackbar } from '../../../ui/hooks/useSnackbar';
 import { useTwitterNotifications } from './useTwitterNotifications';
+import { useTranslation } from 'react-i18next';
 
 /**
  * Perform all necessary processing/transforms from the raw database
@@ -32,6 +33,7 @@ function processTweet(tweet) {
 export const useTwitterService = () => {
   const { addAlert } = useSnackbar();
   const { setNotification } = useTwitterNotifications();
+  const { t } = useTranslation();
 
   const setProfile = useSetRecoilState(twitterState.profile);
   const setUpdateProfileLoading = useSetRecoilState(twitterState.updateProfileLoading);
@@ -47,12 +49,19 @@ export const useTwitterService = () => {
     setFilteredTweets(tweets.map(processTweet));
   };
 
+  const handleAddAlert = ({ message, type }: IAlert) => {
+    addAlert({
+      message: t(`APPS_${message}`),
+      type,
+    });
+  };
+
   useNuiEvent(APP_TWITTER, 'getOrCreateTwitterProfile', setProfile);
   useNuiEvent(APP_TWITTER, 'updateProfileLoading', setUpdateProfileLoading);
-  useNuiEvent(APP_TWITTER, 'updateProfileResult', addAlert);
+  useNuiEvent(APP_TWITTER, 'updateProfileResult', handleAddAlert);
   useNuiEvent(APP_TWITTER, 'fetchTweets', _setTweets);
   useNuiEvent(APP_TWITTER, 'fetchTweetsFiltered', _setFilteredTweets);
   useNuiEvent(APP_TWITTER, 'createTweetLoading', setCreateLoading);
-  useNuiEvent(APP_TWITTER, 'createTweetResult', addAlert);
+  useNuiEvent(APP_TWITTER, 'createTweetResult', handleAddAlert);
   useNuiEvent(APP_TWITTER, 'createTweetBroadcast', setNotification);
 };

--- a/phone/src/locale/en.json
+++ b/phone/src/locale/en.json
@@ -125,6 +125,8 @@
     "GENERIC_CLOSE": "Close",
     "GENERIC_CANCEL": "Cancel",
     "GENERIC_TITLE": "Title",
-    "GENERIC_CONTENT": "Content"
+    "GENERIC_CONTENT": "Content",
+    "GENERIC_WRITE_TO_CLIPBOARD_TOOLTIP": "Copy {{ content }}",
+    "GENERIC_WRITE_TO_CLIPBOARD_MESSAGE": "Copied {{content}} to clipboard!"
   }
 }

--- a/phone/src/ui/components/Snackbar.tsx
+++ b/phone/src/ui/components/Snackbar.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { makeStyles } from '@material-ui/core';
-import { useTranslation } from 'react-i18next';
 import { useSnackbar } from '../hooks/useSnackbar';
 import Alert from './Alert';
 
@@ -22,12 +21,11 @@ const useStyles = makeStyles({
 
 export const Snackbar = () => {
   const classes = useStyles();
-  const { t } = useTranslation();
   const { alert } = useSnackbar();
 
   return (
     <div className={classes.root}>
-      {alert ? <Alert severity={alert.type}>{t('APPS_' + alert.message)}</Alert> : null}
+      {alert ? <Alert severity={alert.type}>{alert.message}</Alert> : null}
     </div>
   );
 };

--- a/phone/src/ui/hooks/useSnackbar.ts
+++ b/phone/src/ui/hooks/useSnackbar.ts
@@ -3,8 +3,10 @@ import { SnackbarContext } from '../providers/SnackbarProvider';
 
 export interface IAlert {
   message: string;
-  type: 'success' | 'error' | 'info';
+  type: AlertType;
 }
+
+export type AlertType = 'success' | 'error' | 'info';
 
 interface ISnackBar {
   addAlert: ({ message, type }: IAlert) => void;


### PR DESCRIPTION
Change to Snackbar message property to allow for any string rather than a translation key

**New**
```jsx
export const Snackbar = () => {
  const classes = useStyles();
  const { alert } = useSnackbar();

  return (
    <div className={classes.root}>
      {alert ? <Alert severity={alert.type}>{alert.message}</Alert> : null}
    </div>
  );
};
```