### PR TITLE
Feature/twitter refresh

### DIFF
--- a/phone/src/apps/twitter/components/TwitterApp.tsx
+++ b/phone/src/apps/twitter/components/TwitterApp.tsx
@@ -34,27 +34,11 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-const TWEETS_REFRESH_RATE = 15000; // TODO move this to twitter config
-
 export const TwitterApp = () => {
   const classes = useStyles();
   const { modalVisible, setModalVisible } = useModal();
   const [activePage, setActivePage] = useState(0);
   const { profile } = useProfile();
-
-  useEffect(() => {
-    // this is a polling implementation. It is possible that
-    // there is some interaction where, on a new tweet, all
-    // clients are sent the updated query data. Until that can
-    // be accomplished this is naive but robust.
-    //
-    // TODO don't call fetchTweets - implement a function that only
-    // returns tweets that we don't already have
-    const timeout = window.setTimeout(() => {
-      Nui.send('phone:fetchTweets', {});
-    }, TWEETS_REFRESH_RATE);
-    return () => window.clearTimeout(timeout);
-  }, []);
 
   // before any other action can be taken by the user we force
   // them have a profile name

--- a/phone/src/apps/twitter/components/TwitterApp.tsx
+++ b/phone/src/apps/twitter/components/TwitterApp.tsx
@@ -34,12 +34,27 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
+const TWEETS_REFRESH_RATE = 15000; // TODO move this to twitter config
 
 export const TwitterApp = () => {
   const classes = useStyles();
   const { modalVisible, setModalVisible } = useModal();
   const [activePage, setActivePage] = useState(0);
   const { profile } = useProfile();
+
+  useEffect(() => {
+    // this is a polling implementation. It is possible that
+    // there is some interaction where, on a new tweet, all
+    // clients are sent the updated query data. Until that can
+    // be accomplished this is naive but robust.
+    //
+    // TODO don't call fetchTweets - implement a function that only
+    // returns tweets that we don't already have
+    const timeout = window.setTimeout(() => {
+      Nui.send('phone:fetchTweets', {});
+    }, TWEETS_REFRESH_RATE);
+    return () => window.clearTimeout(timeout);
+  }, []);
 
   // before any other action can be taken by the user we force
   // them have a profile name

--- a/phone/src/apps/twitter/components/TwitterApp.tsx
+++ b/phone/src/apps/twitter/components/TwitterApp.tsx
@@ -34,7 +34,6 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-const TWEETS_REFRESH_RATE = 15000; // TODO move this to twitter config
 
 export const TwitterApp = () => {
   const classes = useStyles();
@@ -43,17 +42,7 @@ export const TwitterApp = () => {
   const { profile } = useProfile();
 
   useEffect(() => {
-    // this is a polling implementation. It is possible that
-    // there is some interaction where, on a new tweet, all
-    // clients are sent the updated query data. Until that can
-    // be accomplished this is naive but robust.
-    //
-    // TODO don't call fetchTweets - implement a function that only
-    // returns tweets that we don't already have
-    const timeout = window.setTimeout(() => {
-      Nui.send('phone:fetchTweets', {});
-    }, TWEETS_REFRESH_RATE);
-    return () => window.clearTimeout(timeout);
+    Nui.send('phone:getOrCreateTwitterProfile', {});
   }, []);
 
   // before any other action can be taken by the user we force

--- a/phone/src/apps/twitter/components/TwitterApp.tsx
+++ b/phone/src/apps/twitter/components/TwitterApp.tsx
@@ -41,10 +41,6 @@ export const TwitterApp = () => {
   const [activePage, setActivePage] = useState(0);
   const { profile } = useProfile();
 
-  useEffect(() => {
-    Nui.send('phone:getOrCreateTwitterProfile', {});
-  }, []);
-
   // before any other action can be taken by the user we force
   // them have a profile name
   const promptProfileName = profile && (!profile.profile_name || !profile.profile_name.trim());

--- a/phone/src/apps/twitter/hooks/useTwitterNotifications.ts
+++ b/phone/src/apps/twitter/hooks/useTwitterNotifications.ts
@@ -11,7 +11,7 @@ import { twitterState } from './state';
 const NOTIFICATION_ID = 'twitter:broadcast';
 
 function isMentioned(profileName: string, message: string) {
-  return !message.toLowerCase().includes(profileName.toLowerCase());
+  return message.toLowerCase().includes(profileName.toLowerCase());
 }
 
 export const useTwitterNotifications = () => {
@@ -30,7 +30,7 @@ export const useTwitterNotifications = () => {
     const titleStr = isRetweet
       ? 'APPS_TWITTER_NEW_RETWEET_BROADCAST'
       : 'APPS_TWITTER_NEW_BROADCAST';
-
+    
     const currentProfileName = profile.profile_name;
     // we don't want notifications of our own tweets
     if (currentProfileName === profile_name) return;
@@ -39,7 +39,7 @@ export const useTwitterNotifications = () => {
     // mentioned in
     if (
       settings.TWITTER_notiFilter.value === SETTING_MENTIONS &&
-      isMentioned(currentProfileName, message)
+      !isMentioned(currentProfileName, message)
     )
       return;
 

--- a/phone/src/apps/twitter/hooks/useTwitterNotifications.ts
+++ b/phone/src/apps/twitter/hooks/useTwitterNotifications.ts
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import { useRecoilState, useRecoilValue } from 'recoil';
+import { Profile } from '../../../../../typings/twitter';
 
 import { useApp } from '../../../os/apps/hooks/useApps';
 import { useNotifications } from '../../../os/notifications/hooks/useNotifications';
@@ -24,14 +25,17 @@ export const useTwitterNotifications = () => {
   const { icon, notificationIcon } = useApp('TWITTER');
 
   const [unreadCount, setUnreadCount] = useRecoilState(twitterState.unreadTweetsCount);
-  const profile = useRecoilValue(twitterState.profile);
+  const profile: Profile | null = useRecoilValue(twitterState.profile);
 
   const setNotification = ({ profile_name, message, isRetweet }) => {
     const titleStr = isRetweet
       ? 'APPS_TWITTER_NEW_RETWEET_BROADCAST'
       : 'APPS_TWITTER_NEW_BROADCAST';
-    
-    const currentProfileName = profile.profile_name;
+
+    // profile defaults to null, if for some reason it is not initialized
+    // defend against this case
+    const currentProfileName = profile?.profile_name;
+
     // we don't want notifications of our own tweets
     if (currentProfileName === profile_name) return;
 
@@ -39,6 +43,7 @@ export const useTwitterNotifications = () => {
     // mentioned in
     if (
       settings.TWITTER_notiFilter.value === SETTING_MENTIONS &&
+      profile &&
       !isMentioned(currentProfileName, message)
     )
       return;

--- a/phone/src/apps/twitter/hooks/useTwitterNotifications.ts
+++ b/phone/src/apps/twitter/hooks/useTwitterNotifications.ts
@@ -34,7 +34,9 @@ export const useTwitterNotifications = () => {
 
     // profile defaults to null, if for some reason it is not initialized
     // defend against this case
-    const currentProfileName = profile?.profile_name;
+    if (!profile) return;
+
+    const currentProfileName = profile.profile_name;
 
     // we don't want notifications of our own tweets
     if (currentProfileName === profile_name) return;
@@ -43,7 +45,6 @@ export const useTwitterNotifications = () => {
     // mentioned in
     if (
       settings.TWITTER_notiFilter.value === SETTING_MENTIONS &&
-      profile &&
       !isMentioned(currentProfileName, message)
     )
       return;

--- a/phone/src/apps/twitter/hooks/useTwitterNotifications.ts
+++ b/phone/src/apps/twitter/hooks/useTwitterNotifications.ts
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import { useRecoilState, useRecoilValue } from 'recoil';
-import { Profile } from '../../../../../typings/twitter';
+import { Tweet, Profile } from '../../../../../typings/twitter';
 
 import { useApp } from '../../../os/apps/hooks/useApps';
 import { useNotifications } from '../../../os/notifications/hooks/useNotifications';
@@ -27,7 +27,7 @@ export const useTwitterNotifications = () => {
   const [unreadCount, setUnreadCount] = useRecoilState(twitterState.unreadTweetsCount);
   const profile: Profile | null = useRecoilValue(twitterState.profile);
 
-  const setNotification = ({ profile_name, message, isRetweet }) => {
+  const setNotification = ({ profile_name, message, isRetweet }: Tweet) => {
     const titleStr = isRetweet
       ? 'APPS_TWITTER_NEW_RETWEET_BROADCAST'
       : 'APPS_TWITTER_NEW_BROADCAST';

--- a/phone/src/apps/twitter/hooks/useTwitterService.ts
+++ b/phone/src/apps/twitter/hooks/useTwitterService.ts
@@ -1,4 +1,3 @@
-import { useSetRecoilState } from 'recoil';
 import { useRecoilState, useSetRecoilState } from 'recoil';
 import { v4 as uuidv4 } from 'uuid';
 

--- a/phone/src/apps/twitter/hooks/useTwitterService.ts
+++ b/phone/src/apps/twitter/hooks/useTwitterService.ts
@@ -1,4 +1,5 @@
 import { useSetRecoilState } from 'recoil';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 import { v4 as uuidv4 } from 'uuid';
 
 import { useNuiEvent } from '../../../os/nui-events/hooks/useNuiEvent';
@@ -8,6 +9,7 @@ import { twitterState } from './state';
 import { IAlert, useSnackbar } from '../../../ui/hooks/useSnackbar';
 import { useTwitterNotifications } from './useTwitterNotifications';
 import { useTranslation } from 'react-i18next';
+import { Tweet } from '../../../common/typings/twitter';
 
 /**
  * Perform all necessary processing/transforms from the raw database
@@ -38,7 +40,7 @@ export const useTwitterService = () => {
   const setProfile = useSetRecoilState(twitterState.profile);
   const setUpdateProfileLoading = useSetRecoilState(twitterState.updateProfileLoading);
 
-  const setTweets = useSetRecoilState(twitterState.tweets);
+  const [currentTweets, setTweets] = useRecoilState(twitterState.tweets);
   const setFilteredTweets = useSetRecoilState(twitterState.filteredTweets);
   const setCreateLoading = useSetRecoilState(twitterState.createTweetLoading);
 
@@ -47,6 +49,13 @@ export const useTwitterService = () => {
   };
   const _setFilteredTweets = (tweets) => {
     setFilteredTweets(tweets.map(processTweet));
+  };
+
+  const handleTweetBroadcast = (tweet: Tweet) => {
+    setNotification(tweet);
+    const processedTweet = processTweet(tweet);
+    const updatedTweets = [processedTweet].concat(currentTweets);
+    setTweets(updatedTweets);
   };
 
   const handleAddAlert = ({ message, type }: IAlert) => {
@@ -63,6 +72,6 @@ export const useTwitterService = () => {
   useNuiEvent(APP_TWITTER, 'fetchTweetsFiltered', _setFilteredTweets);
   useNuiEvent(APP_TWITTER, 'createTweetLoading', setCreateLoading);
   useNuiEvent(APP_TWITTER, 'createTweetResult', handleAddAlert);
-  useNuiEvent(APP_TWITTER, 'createTweetBroadcast', setNotification);
-  useNuiEvent(APP_TWITTER, 'phone:retweetExists', handleAddAlert);
+  useNuiEvent(APP_TWITTER, 'createTweetBroadcast', handleTweetBroadcast);
+  useNuiEvent(APP_TWITTER, 'phone:retweetExists', handleAddAlert)
 };

--- a/typings/twitter.ts
+++ b/typings/twitter.ts
@@ -11,6 +11,7 @@ export interface Tweet extends NewTweet {
   profile_name: string;
   profile_id: number;
   id: number;
+  identifier: string;
   isMine: boolean;
   isLiked: boolean;
   isReported: boolean;
@@ -24,6 +25,14 @@ export interface Tweet extends NewTweet {
   retweetAvatarUrl: string;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface Image {
+  id: string;
+  link: string;
+}
+export interface FormattedTweet extends Omit<Tweet, 'images'> {
+  images: Image[];
 }
 
 export interface Profile {


### PR DESCRIPTION
This takes the already existing functionality of broadcasting tweets that was implemented for notifications and just prepends the tweet to the list of existing tweets. This means that the list of tweets on the phone should be updated in real time without making database calls.

I tested this as much as I could with two accounts connected to the same local server, I _assume_ it will work at a larger scale with many players.
[Feature/twitter refresh](https://app.gitkraken.com/glo/card/b0bc1bd7a3e64950b90089ae84d2173f)