### PR TITLE
tweak(dialer): Several fixes and improvements

### DIFF
--- a/phone/src/apps/dialer/components/DialerApp.tsx
+++ b/phone/src/apps/dialer/components/DialerApp.tsx
@@ -28,7 +28,7 @@ export const DialerApp = () => {
             <Route exact path="/phone">
               <DialerHistory calls={history} />
             </Route>
-            <Route path="/phone/contacts" component={ContactList}></Route>
+            <Route path="/phone/contacts" component={ContactList} />
           </Switch>
         </AppContent>
         <DialerNavBar />
@@ -39,18 +39,18 @@ export const DialerApp = () => {
 
 InjectDebugData([
   {
-    app: 'DAILER',
+    app: 'DIALER',
     method: 'setHistory',
     data: [
       {
         id: 1,
         transmitter: '636-6496',
-        start: 1612301545782,
+        start: 1615946292,
       },
       {
         id: 2,
         transmitter: '777-7777',
-        start: 1612301545782,
+        start: 1615946292,
       },
     ],
   },

--- a/phone/src/apps/dialer/components/DialerInput.tsx
+++ b/phone/src/apps/dialer/components/DialerInput.tsx
@@ -50,7 +50,7 @@ export const DialerInput = () => {
         value={inputVal}
         onChange={(e) => set(e.target.value)}
       />
-      <IconButton color="primary" className={classes.iconBtn}>
+      <IconButton color="primary" className={classes.iconBtn} disabled={inputVal <= ''}>
         <PhoneIcon fontSize="large" onClick={() => handleCall(inputVal)} />
       </IconButton>
       <IconButton className={classes.iconBtn}>

--- a/phone/src/apps/dialer/components/DialerInput.tsx
+++ b/phone/src/apps/dialer/components/DialerInput.tsx
@@ -3,7 +3,7 @@ import { Box, IconButton, InputBase, Paper } from '@material-ui/core';
 import { makeStyles, Theme } from '@material-ui/core/styles';
 import PhoneIcon from '@material-ui/icons/Phone';
 import PersonAddIcon from '@material-ui/icons/PersonAdd';
-import { DialInputCtx } from '../context/InputContext';
+import { DialInputCtx, IDialInputCtx } from '../context/InputContext';
 import Nui from '../../../os/nui-events/utils/Nui';
 import { useHistory } from 'react-router-dom';
 
@@ -30,7 +30,7 @@ export const DialerInput = () => {
   const classes = useStyles();
   const history = useHistory();
 
-  const { inputVal } = useContext(DialInputCtx);
+  const { inputVal, set } = useContext<IDialInputCtx>(DialInputCtx);
 
   const handleCall = (number: string) => {
     Nui.send('phone:beginCall', {
@@ -44,7 +44,12 @@ export const DialerInput = () => {
 
   return (
     <Box component={Paper} className={classes.root}>
-      <InputBase placeholder="Enter a number" className={classes.input} value={inputVal} />
+      <InputBase
+        placeholder="Enter a number"
+        className={classes.input}
+        value={inputVal}
+        onChange={(e) => set(e.target.value)}
+      />
       <IconButton color="primary" className={classes.iconBtn}>
         <PhoneIcon fontSize="large" onClick={() => handleCall(inputVal)} />
       </IconButton>

--- a/phone/src/apps/dialer/components/views/DialPage.tsx
+++ b/phone/src/apps/dialer/components/views/DialPage.tsx
@@ -28,6 +28,7 @@ const DialPage = () => {
           add: (val: string) => setInputVal(inputVal + val),
           removeOne: () => setInputVal(inputVal.slice(0, -1)),
           clear: () => setInputVal(''),
+          set: (val: string) => setInputVal(val),
         }}
       >
         <DialerInput />

--- a/phone/src/apps/dialer/components/views/DialerHistory.tsx
+++ b/phone/src/apps/dialer/components/views/DialerHistory.tsx
@@ -9,11 +9,11 @@ import Nui from '../../../../os/nui-events/utils/Nui';
 import { useSimcard } from '../../../../os/simcard/hooks/useSimcard';
 import { useContacts } from '../../../contacts/hooks/useContacts';
 import { ICall } from '../../../../../../typings/call';
-import dayjs from 'dayjs';
 import { useTranslation } from 'react-i18next';
 import { Box, IconButton, ListItemIcon, ListItemText } from '@material-ui/core';
 import { useHistory } from 'react-router-dom';
 import { makeStyles, Theme } from '@material-ui/core/styles';
+import dayjs from 'dayjs';
 
 const useStyles = makeStyles((theme: Theme) => ({
   callForward: {
@@ -25,7 +25,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 }));
 
 export const DialerHistory = ({ calls }) => {
-  const { number } = useSimcard();
+  const { number: myNumber } = useSimcard();
   const { getDisplayByNumber } = useContacts();
 
   const classes = useStyles();
@@ -44,9 +44,9 @@ export const DialerHistory = ({ calls }) => {
     return (
       <Box display="flex" justifyContent="center" alignItems="center" paddingTop={35}>
         <p>
-          You got no friends!
-          <span role="img" aria-label="deal with it">
-            😎
+          {t('APPS_DIALER_NO_HISTORY')}
+          <span role="img" aria-label="sad">
+            😞
           </span>
         </p>
       </Box>
@@ -56,45 +56,57 @@ export const DialerHistory = ({ calls }) => {
   return (
     <List disablePadding>
       {calls.map((call: ICall) =>
-        call.transmitter === number ? (
+        call.transmitter === myNumber ? (
           <ListItem key={call.id} divider>
-            <ListItemIcon>{<PhoneForwardedIcon className={classes.callForward} />}</ListItemIcon>
+            <ListItemIcon>
+              <PhoneForwardedIcon className={classes.callForward} />
+            </ListItemIcon>
 
             <ListItemText
               primary={getDisplayByNumber(call.receiver)}
-              secondary={dayjs.unix(call.start).format(t('DATE_TIME_FORMAT'))}
+              secondary={
+                // TODO: Locale changes are pending #168 merge
+                dayjs().to(dayjs.unix(call.start))
+              }
             />
             <IconButton onClick={() => handleCall(call.receiver)}>{<PhoneIcon />}</IconButton>
 
-            {getDisplayByNumber(call.transmitter) === call.transmitter ? (
+            {getDisplayByNumber(call.transmitter) === call.transmitter && (
               <IconButton
                 onClick={() =>
                   history.push(`/contacts/-1?addNumber=${call.transmitter}&referal=/phone/contacts`)
                 }
               >
-                {<PersonAddIcon />}
+                <PersonAddIcon />
               </IconButton>
-            ) : null}
+            )}
           </ListItem>
         ) : (
           <ListItem key={call.id} divider>
-            <ListItemIcon>{<PhoneCallbackIcon className={classes.callBack} />}</ListItemIcon>
+            <ListItemIcon>
+              <PhoneCallbackIcon className={classes.callBack} />
+            </ListItemIcon>
 
             <ListItemText
               primary={getDisplayByNumber(call.transmitter)}
-              secondary={dayjs.unix(call.start).format(t('DATE_TIME_FORMAT'))}
+              secondary={
+                // TODO: Locale changes are pending #168 merge
+                dayjs().to(dayjs.unix(call.start))
+              }
             />
-            <IconButton onClick={() => handleCall(call.transmitter)}>{<PhoneIcon />}</IconButton>
+            <IconButton onClick={() => handleCall(call.transmitter)}>
+              <PhoneIcon />
+            </IconButton>
 
-            {getDisplayByNumber(call.transmitter) === call.transmitter ? (
+            {getDisplayByNumber(call.transmitter) === call.transmitter && (
               <IconButton
                 onClick={() =>
                   history.push(`/contacts/-1?addNumber=${call.transmitter}&referal=/phone/contacts`)
                 }
               >
-                {<PersonAddIcon />}
+                <PersonAddIcon />
               </IconButton>
-            ) : null}
+            )}
           </ListItem>
         ),
       )}

--- a/phone/src/apps/dialer/context/InputContext.tsx
+++ b/phone/src/apps/dialer/context/InputContext.tsx
@@ -5,6 +5,7 @@ export interface IDialInputCtx {
   add: (char: string | number) => void;
   removeOne: () => void;
   clear: () => void;
+  set: (val) => void;
 }
 
 export const DialInputCtx = createContext(null);

--- a/phone/src/apps/dialer/hooks/useDialHistory.ts
+++ b/phone/src/apps/dialer/hooks/useDialHistory.ts
@@ -1,11 +1,7 @@
 import { useRecoilValue } from 'recoil';
 import { ICall } from '../../../../../typings/call';
 import { dialState } from './state';
-interface ICallUI {
-  history: ICall[];
-}
 
-export const useDialHistory = (): ICallUI[] => {
-  const history = useRecoilValue(dialState.history);
-  return history;
+export const useDialHistory = () => {
+  return useRecoilValue<ICall[]>(dialState.history);
 };

--- a/phone/src/apps/dialer/hooks/useDialService.ts
+++ b/phone/src/apps/dialer/hooks/useDialService.ts
@@ -4,5 +4,5 @@ import { dialState } from './state';
 
 export const useDialService = () => {
   const setHistory = useSetRecoilState(dialState.history);
-  useNuiEvent('DAILER', 'setHistory', setHistory);
+  useNuiEvent('DIALER', 'setHistory', setHistory);
 };

--- a/phone/src/index.tsx
+++ b/phone/src/index.tsx
@@ -9,6 +9,12 @@ import './main.css';
 import PhoneConfig from './config/default.json';
 import { PhoneContainer } from './PhoneContainer';
 import attachMockNuiEvent from './os/debug/AttachMockNuiEvent';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import updateLocale from 'dayjs/plugin/updateLocale';
+
+dayjs.extend(relativeTime);
+dayjs.extend(updateLocale);
 
 // Enable Sentry when config setting is true and when in prod
 if (PhoneConfig.SentryErrorMetrics && process.env.NODE_ENV !== 'development') {

--- a/phone/src/locale/en.json
+++ b/phone/src/locale/en.json
@@ -3,13 +3,28 @@
     "DATE_FORMAT": "MM/DD/YYYY",
     "DATE_TIME_FORMAT": "MM/DD/YYYY hh:mm A",
     "SETTINGS": {
-      "CATEGORY": {
-        "APPEARANCE": "Appearance",
-        "PHONE": "Phone"
-      },
-      "OPTIONS": {
-        "LANGUAGE": "Language"
-      }
+        "CATEGORY": {
+            "APPEARANCE": "Appearance",
+            "PHONE": "Phone"
+        },
+        "OPTIONS": {
+            "LANGUAGE": "Language"
+        }
+    },
+    "RELATIVE_TIME": {
+      "future": "in %s",
+      "past": "%s ago",
+      "s": "a few seconds",
+      "m": "a minute",
+      "mm": "%d minutes",
+      "h": "an hour",
+      "hh": "%d hours",
+      "d": "a day",
+      "dd": "%d days",
+      "M": "a month",
+      "MM": "%d months",
+      "y": "a year",
+      "yy": "%d years"
     },
 
     "COMING_SOON": "Coming soon...",
@@ -34,6 +49,7 @@
     "APPS_DIALER_ACCEPT_CALL": "Accept",
     "APPS_DIALER_REJECT_CALL": "Reject",
     "APPS_DIALER_END_CALL": "End",
+    "APPS_DIALER_NO_HISTORY": "You have no call history",
 
     "APPS_TWITTER_TWEET": "Tweet",
     "APPS_TWITTER_TWEET_MESSAGE_PLACEHOLDER": "What's happening?",

--- a/resources/client/cl_call.ts
+++ b/resources/client/cl_call.ts
@@ -121,7 +121,7 @@ function openCallModal(show: boolean) {
 onNet(events.PHONE_CALL_SEND_HISTORY, (calls: ICall) => {
   SendNuiMessage(
     JSON.stringify({
-      app: 'DAILER',
+      app: 'DIALER',
       method: 'setHistory',
       data: calls,
     }),


### PR DESCRIPTION
Time has been changed to a relative format. Locale specifics are pending
merge of #168.

Several typos have been fixed where "DAILER" was referenced instead of
"DIALER"

A translation key was added for when a user has no call history.

The input box has been unlocked so users can use their keyboard directly
rather than using the dial pad.