### PR TITLE
RFR: Adjust identifier length + add backticks.

### DIFF
--- a/import.sql
+++ b/import.sql
@@ -4,12 +4,12 @@ ALTER TABLE `users` ADD COLUMN `phone_number` VARCHAR(20) DEFAULT NULL;
 INSERT INTO `items` (`name`, `label`, `weight`, `rare`, `can_remove`) VALUES ('phone', 'Phone', 1, 0, 1);
 INSERT INTO `items` (`name`, `label`, `weight`, `rare`, `can_remove`) VALUES ('dphone', 'Destroyed Phone', 1, 0, 1);
 
-CREATE TABLE IF NOT EXISTS npwd_phone_contacts (
-  id int(11) NOT NULL AUTO_INCREMENT,
-  identifier varchar(60) DEFAULT NULL,
-  avatar varchar(512) DEFAULT NULL,
-  number varchar(10) DEFAULT NULL,
-  display varchar(60) NOT NULL DEFAULT '',
+CREATE TABLE IF NOT EXISTS `npwd_phone_contacts` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `identifier` varchar(48) DEFAULT NULL,
+  `avatar` varchar(512) DEFAULT NULL,
+  `number` varchar(10) DEFAULT NULL,
+  `display` varchar(60) NOT NULL DEFAULT '',
   PRIMARY KEY (id)
 );
 
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS `npwd_twitter_tweets` (
   `createdAt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updatedAt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `likes` int NOT NULL DEFAULT '0',
-  `identifier` varchar(40) NOT NULL,
+  `identifier` varchar(48) NOT NULL,
   `visible` tinyint NOT NULL DEFAULT '1',
   `images` varchar(1000) DEFAULT '',
   `retweet` int DEFAULT NULL,
@@ -30,7 +30,7 @@ CREATE TABLE IF NOT EXISTS `npwd_twitter_tweets` (
 CREATE TABLE IF NOT EXISTS `npwd_twitter_profiles` (
   `id` int NOT NULL AUTO_INCREMENT,
   `profile_name` varchar(90) NOT NULL,
-  `identifier` varchar(40) NOT NULL,
+  `identifier` varchar(48) NOT NULL,
 #   Default Profile avatar can be set here
   `avatar_url` varchar(255) DEFAULT 'https://beta.iodine.gg/QrEvq.png',
   `bio` varchar(512) DEFAULT NULL,
@@ -56,7 +56,7 @@ CREATE TABLE IF NOT EXISTS `npwd_twitter_likes` (
 
 CREATE TABLE IF NOT EXISTS `npwd_match_profiles` (
   `id` int NOT NULL AUTO_INCREMENT,
-  `identifier` varchar(255) NOT NULL,
+  `identifier` varchar(48) NOT NULL,
   `name` varchar(90) NOT NULL,
   `image` varchar(255) NOT NULL,
   `bio` varchar(512) DEFAULT NULL,
@@ -72,7 +72,7 @@ CREATE TABLE IF NOT EXISTS `npwd_match_profiles` (
 
 CREATE TABLE IF NOT EXISTS `npwd_match_views` (
   `id` int NOT NULL AUTO_INCREMENT,
-  `identifier` varchar(40) NOT NULL,
+  `identifier` varchar(48) NOT NULL,
   `profile` int NOT NULL,
   `liked` tinyint DEFAULT '0',
   `createdAt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -82,32 +82,32 @@ CREATE TABLE IF NOT EXISTS `npwd_match_views` (
   CONSTRAINT `match_profile` FOREIGN KEY (`profile`) REFERENCES `npwd_match_profiles` (`id`)
 );
 
-CREATE TABLE IF NOT EXISTS npwd_notes (
-  id int(11) NOT NULL AUTO_INCREMENT,
-  identifier varchar(255) NOT NULL,
-  title varchar(255) NOT NULL,
-  content varchar(255) NOT NULL,
+CREATE TABLE IF NOT EXISTS `npwd_notes` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `identifier` varchar(48) NOT NULL,
+  `title` varchar(255) NOT NULL,
+  `content` varchar(255) NOT NULL,
   PRIMARY KEY (id)
 );
 
-CREATE TABLE IF NOT EXISTS npwd_marketplace_listings (
-  id int(11) NOT NULL AUTO_INCREMENT,
-  identifier varchar(255) DEFAULT NULL,
-  username varchar(255) DEFAULT NULL,
-  name varchar(50) DEFAULT NULL,
-  number varchar(255) NOT NULL,
-  title varchar(255) DEFAULT NULL,
-  url varchar(255) DEFAULT NULL,
-  description varchar(255) NOT NULL,
-  createdAt timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  updatedAt timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+CREATE TABLE IF NOT EXISTS `npwd_marketplace_listings` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `identifier` varchar(48) DEFAULT NULL,
+  `username` varchar(255) DEFAULT NULL,
+  `name` varchar(50) DEFAULT NULL,
+  `number` varchar(255) NOT NULL,
+  `title` varchar(255) DEFAULT NULL,
+  `url` varchar(255) DEFAULT NULL,
+  `description` varchar(255) NOT NULL,
+  `createdAt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updatedAt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (id)
 );
 
-CREATE TABLE IF NOT EXISTS npwd_marketplace_reports (
-  id int(11) NOT NULL AUTO_INCREMENT,
-  listing_id int(11) DEFAULT NULL,
-  profile varchar(255) DEFAULT NULL,
+CREATE TABLE IF NOT EXISTS `npwd_marketplace_reports` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `listing_id` int(11) DEFAULT NULL,
+  `profile` varchar(255) DEFAULT NULL,
   PRIMARY KEY (id)
 );
 
@@ -125,11 +125,11 @@ CREATE TABLE IF NOT EXISTS `npwd_twitter_reports` (
 
 CREATE TABLE IF NOT EXISTS `npwd_messages_groups` (
   `id` int NOT NULL AUTO_INCREMENT,
-  `user_identifier` varchar(40) NOT NULL,
+  `user_identifier` varchar(48) NOT NULL,
   `createdAt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updatedAt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `group_id` varchar(512) NOT NULL,
-  `participant_identifier` varchar(40) NOT NULL,
+  `participant_identifier` varchar(48) NOT NULL,
   `label` varchar(60) DEFAULT '',
   `unreadCount` int(11) NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`)
@@ -137,7 +137,7 @@ CREATE TABLE IF NOT EXISTS `npwd_messages_groups` (
 
 CREATE TABLE IF NOT EXISTS `npwd_messages_labels` (
   `id` int NOT NULL AUTO_INCREMENT,
-  `user_identifier` varchar(40) NOT NULL,
+  `user_identifier` varchar(48) NOT NULL,
   `label` varchar(60) NOT NULL,
   `createdAt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updatedAt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
@@ -148,7 +148,7 @@ CREATE TABLE IF NOT EXISTS `npwd_messages_labels` (
 CREATE TABLE IF NOT EXISTS `npwd_messages` (
   `id` int NOT NULL AUTO_INCREMENT,
   `message` varchar(512) NOT NULL,
-  `user_identifier` varchar(40) NOT NULL,
+  `user_identifier` varchar(48) NOT NULL,
   `group_id` varchar(512) NOT NULL,
   `isRead` tinyint NOT NULL DEFAULT '0',
   `createdAt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -157,20 +157,20 @@ CREATE TABLE IF NOT EXISTS `npwd_messages` (
   PRIMARY KEY (`id`)
 );
 
-CREATE TABLE IF NOT EXISTS npwd_calls (
-  id int(11) NOT NULL AUTO_INCREMENT,
-  identifier varchar(255) DEFAULT NULL,
-  transmitter varchar(255) NOT NULL,
-  receiver varchar(255) NOT NULL,
-  is_accepted tinyint(4) DEFAULT 0,
-  start varchar(255) DEFAULT NULL,
+CREATE TABLE IF NOT EXISTS `npwd_calls` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `identifier` varchar(48) DEFAULT NULL,
+  `transmitter` varchar(255) NOT NULL,
+  `receiver` varchar(255) NOT NULL,
+  `is_accepted` tinyint(4) DEFAULT 0,
+  `start` varchar(255) DEFAULT NULL,
   end varchar(255) DEFAULT NULL,
   PRIMARY KEY (id)
 );
 
 CREATE TABLE IF NOT EXISTS npwd_phone_gallery (
-  id int(11) NOT NULL AUTO_INCREMENT,
-  identifier varchar(255) DEFAULT NULL,
-  image varchar(255) DEFAULT NULL,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `identifier` varchar(48) DEFAULT NULL,
+  `image` varchar(255) DEFAULT NULL,
   PRIMARY KEY (id)
 );

--- a/import.sql
+++ b/import.sql
@@ -1,8 +1,6 @@
 # comment this out if your server has a different table/location for phone_number
 # or if it already exists in the users table
 ALTER TABLE `users` ADD COLUMN `phone_number` VARCHAR(20) DEFAULT NULL;
-INSERT INTO `items` (`name`, `label`, `weight`, `rare`, `can_remove`) VALUES ('phone', 'Phone', 1, 0, 1);
-INSERT INTO `items` (`name`, `label`, `weight`, `rare`, `can_remove`) VALUES ('dphone', 'Destroyed Phone', 1, 0, 1);
 
 CREATE TABLE IF NOT EXISTS `npwd_phone_contacts` (
   `id` int(11) NOT NULL AUTO_INCREMENT,


### PR DESCRIPTION
Made the default identifier length `48` since this is the maximum length if `license:` isn't removed and is something those using `esx_kashacters` will already have to do. I also adjusted the instances where it was `255` for some reason so those are `48` as well.

The addition of back ticks is just for formatting. The readability is much better inside VS and sql editors as the text is highlighted as a result. Its's also how most of the SQL was anyways.